### PR TITLE
Fix/escape matches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
 
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.2</version>
             <scope>test</scope>

--- a/src/main/java/com/intuit/fuzzymatcher/component/DocumentMatch.java
+++ b/src/main/java/com/intuit/fuzzymatcher/component/DocumentMatch.java
@@ -51,8 +51,9 @@ public class DocumentMatch {
                                     .stream()
                                     .map(d -> d.getScore())
                                     .collect(Collectors.toList());
+                            childScoreList.forEach(score -> System.out.println(score.getMatch()));
                             return new Match<Document>(leftDocumentEntry.getKey(), rightDocumentEntry.getKey(), childScoreList);
                         }))
-                .filter(match -> match.getResult() > match.getData().getThreshold());
+                .filter(match -> match.getResult() >= match.getData().getThreshold());
     }
 }

--- a/src/main/java/com/intuit/fuzzymatcher/component/DocumentMatch.java
+++ b/src/main/java/com/intuit/fuzzymatcher/component/DocumentMatch.java
@@ -32,7 +32,7 @@ public class DocumentMatch {
      * @return Stream of Match of Document type objects
      */
     public Stream<Match<Document>> matchDocuments(Stream<Document> documents) {
-        Stream<Element> elements = documents.flatMap(d -> d.getDistinctNonEmptyElements());
+        Stream<Element> elements = documents.flatMap(d -> d.getPreProcessedElement().stream());
         Stream<Match<Element>> matchedElements = elementMatch.matchElements(elements);
         return rollupDocumentScore(matchedElements);
     }
@@ -51,9 +51,8 @@ public class DocumentMatch {
                                     .stream()
                                     .map(d -> d.getScore())
                                     .collect(Collectors.toList());
-                            childScoreList.forEach(score -> System.out.println(score.getMatch()));
                             return new Match<Document>(leftDocumentEntry.getKey(), rightDocumentEntry.getKey(), childScoreList);
                         }))
-                .filter(match -> match.getResult() >= match.getData().getThreshold());
+                .filter(match -> match.getResult() > match.getData().getThreshold());
     }
 }

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Document.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Document.java
@@ -75,8 +75,21 @@ public class Document implements Matchable {
     }
 
     @Override
-    public long getEmptyChildCount() {
-        return this.elements.stream().filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).count();
+    public long getUnmatchedChildCount(Matchable other) {
+        if (other instanceof Document) {
+            Document o = (Document) other;
+            List<ElementType> emptyChildrenCount =  this.elements.stream()
+                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType)
+                    .collect(Collectors.toList());
+            List<ElementType> oEmptyChildrenCount =  o.elements.stream()
+                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType)
+                    .collect(Collectors.toList());
+            long diffCount= emptyChildrenCount.stream().filter(e -> !oEmptyChildrenCount.contains(e)).count()
+                    + oEmptyChildrenCount.stream().filter(e -> !emptyChildrenCount.contains(e)).count();
+
+            return Math.max(Math.max(diffCount, emptyChildrenCount.size()), oEmptyChildrenCount.size());
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Document.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Document.java
@@ -78,16 +78,14 @@ public class Document implements Matchable {
     public long getUnmatchedChildCount(Matchable other) {
         if (other instanceof Document) {
             Document o = (Document) other;
-            List<ElementType> emptyChildrenCount =  this.elements.stream()
-                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType)
-                    .collect(Collectors.toList());
-            List<ElementType> oEmptyChildrenCount =  o.elements.stream()
-                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType)
-                    .collect(Collectors.toList());
-            long diffCount= emptyChildrenCount.stream().filter(e -> !oEmptyChildrenCount.contains(e)).count()
-                    + oEmptyChildrenCount.stream().filter(e -> !emptyChildrenCount.contains(e)).count();
-
-            return Math.max(Math.max(diffCount, emptyChildrenCount.size()), oEmptyChildrenCount.size());
+            Stream<ElementType> emptyChildrenType =  this.elements.stream()
+                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType);
+            Stream<ElementType> oEmptyChildrenType =  o.elements.stream()
+                    .filter(element -> StringUtils.isEmpty(element.getPreProcessedValue())).map(Element::getType);
+            Set<ElementType> totalEmptyType = Stream.concat(emptyChildrenType, oEmptyChildrenType).collect(Collectors.toSet());
+            long elemTypeCount = this.elements.stream().filter(element -> totalEmptyType.contains(element.getType())).count();
+            long oElemTypeCount = o.elements.stream().filter(element -> totalEmptyType.contains(element.getType())).count();
+            return Math.max(elemTypeCount, oElemTypeCount);
         }
         return 0;
     }

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
@@ -118,8 +118,14 @@ public class Element implements Matchable {
     }
 
     @Override
-    public long getEmptyChildCount() {
-        return getTokens().filter(token -> StringUtils.isEmpty(token.getValue())).count();
+    public long getUnmatchedChildCount(Matchable other) {
+        if (other instanceof Element) {
+            Element o = (Element) other;
+            long emptyChildren = this.getTokens().filter(token -> StringUtils.isEmpty(token.getValue())).count();
+            long oEmptyChildren = o.getTokens().filter(token -> StringUtils.isEmpty(token.getValue())).count();
+            return Math.max(emptyChildren, oEmptyChildren);
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Element.java
@@ -113,8 +113,12 @@ public class Element implements Matchable {
     }
 
     @Override
-    public long getChildCount() {
-        return getTokens().count();
+    public long getChildCount(Matchable other) {
+        if (other instanceof Element) {
+            Element o = (Element) other;
+            return Math.max(this.getTokens().count(), o.getTokens().count());
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
@@ -10,9 +10,9 @@ public interface Matchable {
 
     public long getChildCount();
 
-    public long getEmptyChildCount();
-
     public Function<Match, Score> getScoringFunction();
 
     public double getWeight();
+
+    public long getUnmatchedChildCount(Matchable other);
 }

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Matchable.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
  */
 public interface Matchable {
 
-    public long getChildCount();
+    public long getChildCount(Matchable other);
 
     public Function<Match, Score> getScoringFunction();
 

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Token.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Token.java
@@ -65,7 +65,7 @@ public class Token implements Matchable{
     }
 
     @Override
-    public long getEmptyChildCount() {
+    public long getUnmatchedChildCount(Matchable other) {
         return 0;
     }
 

--- a/src/main/java/com/intuit/fuzzymatcher/domain/Token.java
+++ b/src/main/java/com/intuit/fuzzymatcher/domain/Token.java
@@ -60,7 +60,7 @@ public class Token implements Matchable{
     }
 
     @Override
-    public long getChildCount() {
+    public long getChildCount(Matchable other) {
         return 0;
     }
 

--- a/src/main/java/com/intuit/fuzzymatcher/function/ScoringFunction.java
+++ b/src/main/java/com/intuit/fuzzymatcher/function/ScoringFunction.java
@@ -14,7 +14,7 @@ public interface ScoringFunction extends Function<Match, Score> {
 
     double EXPONENT = 1.5;
     double EXPONENTIAL_INCREASE_THRESHOLD = 0.9;
-    double DEFAULT_EMPTY_ELEMENT_SCORE = 0.5;
+    double DEFAULT_UNMATCHED_CHILD_SCORE = 0.5;
 
     /**
      * For all the childScores in a Match object it calculates the average.
@@ -26,7 +26,7 @@ public interface ScoringFunction extends Function<Match, Score> {
     static ScoringFunction getAverageScore() {
         return match -> {
             List<Score> childScores = match.getChildScores();
-            double numerator = getSumOfResult(childScores) + getEmptyElementScore(match);
+            double numerator = getSumOfResult(childScores) + getUnmatchedChildScore(match);
             double denominator = getMaxChildCount(match);
             return new Score(numerator / denominator, match);
         };
@@ -42,10 +42,12 @@ public interface ScoringFunction extends Function<Match, Score> {
         return match -> {
             List<Score> childScoreList = match.getChildScores();
             double numerator = getSumOfWeightedResult(childScoreList)
-                    + getEmptyElementScore(match);
+                    + getUnmatchedChildScore(match);
+            System.out.println(numerator);
             double denominator = getSumOfWeights(childScoreList)
                     + getMaxChildCount(match)
                     - childScoreList.size();
+            System.out.println(getSumOfWeights(childScoreList) + " " + getMaxChildCount(match) + " "+ childScoreList.size());
             return new Score(numerator / denominator, match);
         };
     }
@@ -64,7 +66,7 @@ public interface ScoringFunction extends Function<Match, Score> {
             if (perfectMatchedElements.size() > 1 && getSumOfResult(perfectMatchedElements) > 1) {
                 double numerator = getExponentiallyIncreasedValue(getSumOfResult(perfectMatchedElements))
                         + getSumOfResult(getNonPerfectMatchedElement(childScoreList))
-                        + getEmptyElementScore(match);
+                        + getUnmatchedChildScore(match);
 
                 double denominator = getExponentiallyIncreasedValue(perfectMatchedElements.size())
                         + getMaxChildCount(match)
@@ -86,11 +88,12 @@ public interface ScoringFunction extends Function<Match, Score> {
             List<Score> childScoreList = match.getChildScores();
             List<Score> perfectMatchedElements = getPerfectMatchedElement(childScoreList);
 
+            // Apply Exponent if match elements > 1
             if (perfectMatchedElements.size() > 1 && getSumOfWeightedResult(perfectMatchedElements) > 1) {
                 List<Score> notPerfectMachedElements = getNonPerfectMatchedElement(childScoreList);
                 double numerator = getExponentiallyIncreasedValue(getSumOfWeightedResult(perfectMatchedElements))
                         + getSumOfWeightedResult(notPerfectMachedElements)
-                        + getEmptyElementScore(match);
+                        + getUnmatchedChildScore(match);
 
                 double denominator = getExponentiallyIncreasedValue(getSumOfWeights(perfectMatchedElements))
                         + getSumOfWeights(notPerfectMachedElements)
@@ -146,9 +149,8 @@ public interface ScoringFunction extends Function<Match, Score> {
         return (double) Long.max(match.getData().getChildCount(), match.getMatchedWith().getChildCount());
     }
 
-    static double getEmptyElementScore(Match match) {
-        int maxCountEmptyElement = Integer.max((int) match.getData().getEmptyChildCount(),
-                (int) match.getMatchedWith().getEmptyChildCount());
-        return DEFAULT_EMPTY_ELEMENT_SCORE * maxCountEmptyElement;
+    static double getUnmatchedChildScore(Match match) {
+        long maxUnmatchedChildCount = match.getData().getUnmatchedChildCount(match.getMatchedWith());
+        return DEFAULT_UNMATCHED_CHILD_SCORE * maxUnmatchedChildCount;
     }
 }

--- a/src/main/java/com/intuit/fuzzymatcher/function/ScoringFunction.java
+++ b/src/main/java/com/intuit/fuzzymatcher/function/ScoringFunction.java
@@ -43,11 +43,9 @@ public interface ScoringFunction extends Function<Match, Score> {
             List<Score> childScoreList = match.getChildScores();
             double numerator = getSumOfWeightedResult(childScoreList)
                     + getUnmatchedChildScore(match);
-            System.out.println(numerator);
             double denominator = getSumOfWeights(childScoreList)
                     + getMaxChildCount(match)
                     - childScoreList.size();
-            System.out.println(getSumOfWeights(childScoreList) + " " + getMaxChildCount(match) + " "+ childScoreList.size());
             return new Score(numerator / denominator, match);
         };
     }
@@ -114,7 +112,7 @@ public interface ScoringFunction extends Function<Match, Score> {
     static ScoringFunction getJaccardScore() {
         return match ->
                 new Score((double) match.getChildScores().size() /
-                        ((match.getData().getChildCount() + match.getMatchedWith().getChildCount() - match.getChildScores().size())), match);
+                        ((match.getData().getChildCount(match.getMatchedWith()))), match);
     }
 
     static double getSumOfWeightedResult(List<Score> childScoreList) {
@@ -146,7 +144,7 @@ public interface ScoringFunction extends Function<Match, Score> {
     }
 
     static double getMaxChildCount(Match match) {
-        return (double) Long.max(match.getData().getChildCount(), match.getMatchedWith().getChildCount());
+        return (double) match.getData().getChildCount(match.getMatchedWith());
     }
 
     static double getUnmatchedChildScore(Match match) {

--- a/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
@@ -55,7 +55,7 @@ public class MatchServiceTest {
                 System.out.println("Data: " + match.getData() + " Matched With: " + match.getMatchedWith() + " Score: " + match.getScore().getResult());
             });
         });
-        Assert.assertEquals(4, result.size());
+        Assert.assertEquals(5, result.size());
     }
 
     @Test
@@ -89,18 +89,18 @@ public class MatchServiceTest {
         inputData.add(new Document.Builder("1")
                 .addElement(new Element.Builder().setType(NAME).setValue("Kapa Limited").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("texas").createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("8204354957 xyz").setThreshold(0.5).setWeight(2).createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("").setThreshold(0.5).setWeight(2).createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("(848) 398-3868").setWeight(2).setThreshold(0.5).createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("kirit@kapalimited.com").setThreshold(0.5).createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("8204354957 xyz").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("(848) 398-3868").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("kirit@kapalimited.com").createElement())
                 .createDocument());
         inputData.add(new Document.Builder("2")
                 .addElement(new Element.Builder().setType(NAME).setValue("Tram Kapa Ltd LLC").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("texas").createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("(848) 398-3868").setWeight(2).setThreshold(0.5).createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("(820) 435-4957").setWeight(2).setThreshold(0.5).createElement())
-                .addElement(new Element.Builder().setType(PHONE).setValue("").setWeight(2).setThreshold(0.5).createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("kirit@nekoproductions.com").setThreshold(0.5).createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("(848) 398-3868").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("(820) 435-4957").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("kirit@nekoproductions.com").createElement())
                 .createDocument());
         Map<Document, List<Match<Document>>> result = matchService.applyMatch(inputData);
         Assert.assertEquals(2, result.size());

--- a/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
@@ -420,21 +420,21 @@ public class MatchServiceTest {
                 .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
                 .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("parker@email.com").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("jamesparker@email.com").createElement())
                 .createDocument());
         inputData.add(new Document.Builder("2")
-                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(NAME).setValue("James").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
                 .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("james@email.com").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("jamesparker@email.com").createElement())
                 .createDocument());
 
         Map<Document, List<Match<Document>>> result = matchService.applyMatch(inputData);
         Assert.assertThat(result.entrySet().stream()
                         .map(entry -> entry.getKey().getKey()).collect(Collectors.toList()),
                 CoreMatchers.hasItems("1", "2"));
-        Assert.assertEquals(0.5, result.entrySet().stream()
-                .map(entry -> entry.getValue()).collect(Collectors.toList()).get(0).get(0).getResult(), 0.0);
+        Assert.assertEquals(0.75, result.entrySet().stream()
+                .map(entry -> entry.getValue()).collect(Collectors.toList()).get(0).get(0).getResult(), 0.01);
     }
 
     @Test
@@ -444,28 +444,29 @@ public class MatchServiceTest {
                 .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
                 .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("parker@email.com").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("jamesparker@email.com").createElement())
                 .createDocument());
         inputData.add(new Document.Builder("2")
-                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(NAME).setValue("James").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
                 .addElement(new Element.Builder().setType(PHONE).setValue("123-123-1234").createElement())
-                .addElement(new Element.Builder().setType(EMAIL).setValue("james@email.com").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("jamesparker@email.com").createElement())
                 .createDocument());
 
         Map<Document, List<Match<Document>>> result = matchService.applyMatch(inputData);
         Assert.assertThat(result.entrySet().stream()
                         .map(entry -> entry.getKey().getKey()).collect(Collectors.toList()),
                 CoreMatchers.hasItems("1", "2"));
-        Assert.assertEquals(0.5, result.entrySet().stream()
-                .map(entry -> entry.getValue()).collect(Collectors.toList()).get(0).get(0).getResult(), 0.0);
+        Assert.assertEquals(0.625, result.entrySet().stream()
+                .map(entry -> entry.getValue()).collect(Collectors.toList()).get(0).get(0).getResult(), 0.01);
     }
 
     public static void writeOutput(Map<String, List<Match<Document>>> result) throws IOException {
         CSVWriter writer = new CSVWriter(new FileWriter("src/test/resources/output.csv"));
         writer.writeNext(new String[]{"Key", "Matched Key", "Score", "Name", "Address", "Email", "Phone"});
 
-        result.entrySet().forEach(entry -> {
+        result.entrySet().stream().sorted(Map.Entry.<String, List<Match<Document>>>comparingByKey())
+                .forEach(entry -> {
             String[] keyArrs = Stream.concat(Stream.of(entry.getKey(), entry.getKey(), ""),
                     getOrderedElements(entry.getValue().stream()
                             .map(match -> match.getData())

--- a/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
@@ -25,11 +25,13 @@ public class DocumentTest {
                 .createDocument();
         Document d2 = new Document.Builder("2")
                 .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
-                .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue(" ").createElement())
                 .addElement(new Element.Builder().setType(PHONE).setValue("123-123-1234").createElement())
                 .addElement(new Element.Builder().setType(EMAIL).setValue("james@email.com").createElement())
                 .createDocument();
 
+        Assert.assertEquals(4, d1.getChildCount(d2));
+        Assert.assertEquals(4, d2.getChildCount(d1));
         Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
     }
 
@@ -48,7 +50,8 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(2, d1.getChildCount(d2));
+        Assert.assertEquals(0, d1.getUnmatchedChildCount(d2));
     }
 
     @Test
@@ -66,7 +69,8 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(3, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(3, d1.getChildCount(d2));
+        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
     }
 
     @Test
@@ -85,6 +89,27 @@ public class DocumentTest {
                 .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
                 .createDocument();
 
-        Assert.assertEquals(4, d1.getUnmatchedChildCount(d2));
+        Assert.assertEquals(4, d1.getChildCount(d2));
+        Assert.assertEquals(3, d1.getUnmatchedChildCount(d2));
+    }
+
+    @Test
+    public void itShouldGetUnmatchedCountForMultiElementTypesWithNonMatch() {
+        Document d1 = new Document.Builder("1")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("123").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+        Document d2 = new Document.Builder("2")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("567").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+
+        Assert.assertEquals(3, d1.getChildCount(d2));
+        Assert.assertEquals(1, d1.getUnmatchedChildCount(d2));
     }
 }

--- a/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
@@ -1,0 +1,73 @@
+package com.intuit.fuzzymatcher.domain;
+
+import com.intuit.fuzzymatcher.AppConfig;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static com.intuit.fuzzymatcher.domain.ElementType.*;
+import static com.intuit.fuzzymatcher.domain.ElementType.EMAIL;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = AppConfig.class)
+public class DocumentTest {
+
+    @Test
+    public void itShouldGetUnmatchedCountForUnbalancedDoc() {
+        Document d1 = new Document.Builder("1")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("parker@email.com").createElement())
+                .createDocument();
+        Document d2 = new Document.Builder("2")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("123-123-1234").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("james@email.com").createElement())
+                .createDocument();
+
+        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
+    }
+
+    @Test
+    public void itShouldGetUnmatchedCountForBalancedDoc() {
+        Document d1 = new Document.Builder("1")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+        Document d2 = new Document.Builder("2")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+
+        Assert.assertEquals(2, d1.getUnmatchedChildCount(d2));
+    }
+
+    @Test
+    @Ignore
+    public void itShouldGetUnmatchedCountForMultiElements() {
+        Document d1 = new Document.Builder("1")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("123").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("234").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+        Document d2 = new Document.Builder("2")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+
+        Assert.assertEquals(4, d1.getUnmatchedChildCount(d2));
+    }
+}

--- a/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/domain/DocumentTest.java
@@ -52,8 +52,25 @@ public class DocumentTest {
     }
 
     @Test
-    @Ignore
-    public void itShouldGetUnmatchedCountForMultiElements() {
+    public void itShouldGetUnmatchedCountForUnbalancedDocWithEmpty() {
+        Document d1 = new Document.Builder("1")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("123").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+        Document d2 = new Document.Builder("2")
+                .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
+                .addElement(new Element.Builder().setType(ADDRESS).setValue("123 Some Street").createElement())
+                .addElement(new Element.Builder().setType(PHONE).setValue("").createElement())
+                .addElement(new Element.Builder().setType(EMAIL).setValue("").createElement())
+                .createDocument();
+
+        Assert.assertEquals(3, d1.getUnmatchedChildCount(d2));
+    }
+
+    @Test
+    public void itShouldGetUnmatchedCountForMultiElementTypes() {
         Document d1 = new Document.Builder("1")
                 .addElement(new Element.Builder().setType(NAME).setValue("James Parker").createElement())
                 .addElement(new Element.Builder().setType(ADDRESS).setValue("").createElement())

--- a/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
@@ -158,7 +158,7 @@ public class ScoringFunctionTest {
 
     private Document getMockDocument(long childCount, long emptyCount) {
         Document doc = mock(Document.class);
-        when(doc.getChildCount()).thenReturn(childCount);
+        when(doc.getChildCount(any())).thenReturn(childCount);
         when(doc.getUnmatchedChildCount(any())).thenReturn(emptyCount);
         return doc;
     }

--- a/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/function/ScoringFunctionTest.java
@@ -10,6 +10,7 @@ import com.intuit.fuzzymatcher.domain.Token;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.matchers.Any;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.intuit.fuzzymatcher.domain.ElementType.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -157,7 +159,7 @@ public class ScoringFunctionTest {
     private Document getMockDocument(long childCount, long emptyCount) {
         Document doc = mock(Document.class);
         when(doc.getChildCount()).thenReturn(childCount);
-        when(doc.getEmptyChildCount()).thenReturn(emptyCount);
+        when(doc.getUnmatchedChildCount(any())).thenReturn(emptyCount);
         return doc;
     }
 

--- a/src/test/resources/demo.csv
+++ b/src/test/resources/demo.csv
@@ -1,6 +1,6 @@
 Names
 Stephen Wilkson
 John Pierre
-Wilson, Stephen
+"Wilson, Stephen"
 Pierre john
 Stephen Kilsman wilkson

--- a/src/test/resources/output.csv
+++ b/src/test/resources/output.csv
@@ -1,3 +1,0 @@
-"Key","Matched Key","Score","Name","Address","Email","Phone"
-"TestMatch","TestMatch","","john doe","546 freeman ave dallas tx 75024","john@doe.com","2122232235"
-"","4","0.8386095222035911","john doe","546 freeman avenue dallas tx 75024","john@doe.com","435-334-2234"

--- a/src/test/resources/test-data.csv
+++ b/src/test/resources/test-data.csv
@@ -27,5 +27,5 @@ Key,Name,Address,Phone,email
 26,Tammi Suder,"8630 Paris Hill Ave. Hattiesburg, MS 39401",(246) 311-0513,tammi_suder@gmail.com
 27,"Profined Dev","1234 some Ave Suite 134-B South Trail CA 90092","3107135589","lokons@gmail.com"
 28,"Blbesto Homez"," Niami GA","4258800224","blbesto0@yahoo.com"
-29,"sad sdf LLC"," ","","info@something.com"
-30,"sdwet ert rdfgh, LLC"," ","","info@abc.com"
+29,"sad sdf LLC"," ","","sad@something.com"
+30,"sdwet ert rdfgh, LLC"," ","","sdwet@abc.com"


### PR DESCRIPTION
Fixes issue with scoring of Document Matches, where document with unbalanced elements did not match correctly

Eg.
Document D1 has Name,Address and Email 
Document D2 has Name,Phone and Email

The Average scoring did not associate correct defaults for elements that do not participate in match 
In this case Address and Phone should each default to 0.5 score (0.5 * 2) Instead of (0.5 * 1)