### PR TITLE
#35 fix DateMatch with NeighborhoodRange greater than 0.91 failing

### DIFF
--- a/src/main/java/com/intuit/fuzzymatcher/component/TokenRepo.java
+++ b/src/main/java/com/intuit/fuzzymatcher/component/TokenRepo.java
@@ -48,6 +48,7 @@ public class TokenRepo {
         TreeSet<Object> tokenBinaryTree;
 
         private final Double AGE_PCT_OF = 10D;
+        private final Double DATE_PCT_OF = 15777e7D; // 5 years of range
 
 
         Repo(MatchType matchType) {
@@ -77,10 +78,15 @@ public class TokenRepo {
                     return tokenElementSet.get(token.getValue());
                 case NEAREST_NEIGHBORS:
                     TokenRange tokenRange;
-                    if (token.getElement().getElementClassification().getElementType().equals(ElementType.AGE)) {
-                        tokenRange = new TokenRange(token, token.getElement().getNeighborhoodRange(), AGE_PCT_OF);
-                    } else {
-                        tokenRange = new TokenRange(token, token.getElement().getNeighborhoodRange());
+                    switch (token.getElement().getElementClassification().getElementType()){
+                        case AGE:
+                            tokenRange = new TokenRange(token, token.getElement().getNeighborhoodRange(), AGE_PCT_OF);
+                            break;
+                        case DATE:
+                            tokenRange = new TokenRange(token, token.getElement().getNeighborhoodRange(), DATE_PCT_OF);
+                            break;
+                        default:
+                            tokenRange = new TokenRange(token, token.getElement().getNeighborhoodRange());
                     }
                     return tokenBinaryTree.subSet(tokenRange.lower, true, tokenRange.higher, true)
                             .stream()
@@ -95,7 +101,6 @@ public class TokenRepo {
 
         private final Object lower;
         private final Object higher;
-        private static final double DATE_SCALE_FACTOR = 1.1;
 
         TokenRange(Token token, double pct, Double pctOf) {
             Object value = token.getValue();
@@ -112,8 +117,8 @@ public class TokenRepo {
                 this.lower = getLower((Float) value, pct, pctOf).floatValue();
                 this.higher = getHigher((Float) value, pct, pctOf).floatValue();
             } else if (value instanceof Date) {
-                this.lower = new Date(getLower(((Date) value).getTime(), pct * DATE_SCALE_FACTOR, pctOf).longValue());
-                this.higher = new Date(getHigher(((Date) value).getTime(), pct * DATE_SCALE_FACTOR, pctOf).longValue());
+                this.lower = new Date(getLower(((Date) value).getTime(), pct, pctOf).longValue());
+                this.higher = new Date(getHigher(((Date) value).getTime(), pct, pctOf).longValue());
             } else {
                 throw new MatchException("Data Type not supported");
             }

--- a/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
+++ b/src/test/java/com/intuit/fuzzymatcher/component/MatchServiceTest.java
@@ -579,6 +579,14 @@ public class MatchServiceTest {
     }
 
     @Test
+    public void itShouldApplyMatchWithDateForHighNeighborhoodRange() {
+        List<Object> dates = Arrays.asList(getDate("01/01/2020"), getDate("01/02/2020"), getDate("02/01/2019"));
+        List<Document> documentList = getTestDocuments(dates, DATE, 0.99); //0.99 neighborhood is about 18 days
+        Map<Document, List<Match<Document>>> result = matchService.applyMatch(documentList);
+        Assert.assertEquals(2, result.size());
+    }
+
+    @Test
     public void itShouldApplyMatchWithAge() {
         List<Object> numbers = Arrays.asList(1, 2, 9, 10, 11, 45, 49, 50, 52, 55, 90, 95, 100, 107, 115);
         List<Document> documentList1 = getTestDocuments(numbers, AGE, null);


### PR DESCRIPTION

Using scale factor of 1.1 for dates causes percent values >0.91 to result in final percentage values >1 which is invalid (0.91 *1.1 = 1.001). It is also counter intuitive as neighborhood_range closer to 1.0  should mean extremely close to equality, but right now 0.90 is translated to 0.99 with the scaling factor thus, currently, 0.9 corresponds to maximum valid value for date type.

Solution:
a) Remove DATE_SCALE_FACTOR as it is not intuitive, and it's effect can by achieved by the end user with higher neighborhood_range . 

b) Default neighborhood_range of 0.9 for dates is around 1800 (5 years) which is is probably too much for day to day matching, so I changed the default to 0.99. This also maintains the current behavior for dates, as  0.9 was scaled by 1.1 to 0.99, thus existing tests pass without changes.

